### PR TITLE
Remove generic Response type and ResponseDecoder from Endpoint.

### DIFF
--- a/B&W.xcodeproj/project.pbxproj
+++ b/B&W.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		BE6E8D852BC09B87003FE826 /* ImageDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6E8D842BC09B87003FE826 /* ImageDataRepository.swift */; };
 		BE6E8D872BC0A1F8003FE826 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6E8D862BC0A1F8003FE826 /* Cancellable.swift */; };
 		BE82DB612BC12DFE006EF9C6 /* FullPathEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE82DB602BC12DFE006EF9C6 /* FullPathEndpointTests.swift */; };
+		BE82DB632BC16A7D006EF9C6 /* DefaultDataTransferServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE82DB622BC16A7D006EF9C6 /* DefaultDataTransferServiceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -135,6 +136,7 @@
 		BE6E8D842BC09B87003FE826 /* ImageDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataRepository.swift; sourceTree = "<group>"; };
 		BE6E8D862BC0A1F8003FE826 /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		BE82DB602BC12DFE006EF9C6 /* FullPathEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullPathEndpointTests.swift; sourceTree = "<group>"; };
+		BE82DB622BC16A7D006EF9C6 /* DefaultDataTransferServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDataTransferServiceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -418,6 +420,7 @@
 			children = (
 				BE6B5F952BBEA43A00B608A1 /* EndpointTests.swift */,
 				BE82DB602BC12DFE006EF9C6 /* FullPathEndpointTests.swift */,
+				BE82DB622BC16A7D006EF9C6 /* DefaultDataTransferServiceTests.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -645,6 +648,7 @@
 				BE0401712BBF29DE006BBE71 /* ProductDetailsViewModelTests.swift in Sources */,
 				BE6B5F9D2BBEC23F00B608A1 /* ProductsDependenciesContainerTests.swift in Sources */,
 				BE6E8D7B2BC087B0003FE826 /* DefaultImageDataRepositoryTests.swift in Sources */,
+				BE82DB632BC16A7D006EF9C6 /* DefaultDataTransferServiceTests.swift in Sources */,
 				BE0401732BBF2A46006BBE71 /* CommonHelpers.swift in Sources */,
 				BE6B5F9B2BBEBD2400B608A1 /* ConfigStub.swift in Sources */,
 			);

--- a/B&W/Data/Endpoints/ProductsEndpoints.swift
+++ b/B&W/Data/Endpoints/ProductsEndpoints.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// The collection of products end points required by ProductsRepository.
 protocol ProductsEndpoints {
-    func getProducts() -> Endpoint<ProductResponseDTO>
+    func getProducts() -> Endpoint
 }
 
 struct ProductsRepositoryEndpoints: ProductsEndpoints {
@@ -19,7 +19,7 @@ struct ProductsRepositoryEndpoints: ProductsEndpoints {
         self.config = config
     }
     
-    func getProducts() -> Endpoint<ProductResponseDTO> {
+    func getProducts() -> Endpoint {
         // Inject config into Endpoint from here.
         Endpoint(config: config, path: "db", method: .get)
     }

--- a/B&W/Data/Repositories/DefaultProductsRepository.swift
+++ b/B&W/Data/Repositories/DefaultProductsRepository.swift
@@ -19,14 +19,15 @@ extension DefaultProductsRepository: ProductsRepository {
         guard !task.isCancelled else { return nil }
 
         let endpoint = endpoints.getProducts()
-        task.networkTask = self.dataTransferService.request(with: endpoint) { result in
-            switch result {
-            case .success(let responseDTO):
-                completion(.success(responseDTO.toDomain()))
-            case .failure(let error):
-                completion(.failure(error))
+        task.networkTask = dataTransferService
+            .request(with: endpoint, responseType: ProductResponseDTO.self) { result in
+                switch result {
+                case .success(let responseDTO):
+                    completion(.success(responseDTO.toDomain()))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
             }
-        }
         return task
     }
 }

--- a/B&W/Network/DataTransferService.swift
+++ b/B&W/Network/DataTransferService.swift
@@ -53,7 +53,7 @@ extension DefaultDataTransferService: DataTransferService {
     }
 
     private func resolve(networkError error: NetworkError) -> DataTransferError {
-        let resolvedError = self.errorHandler.handle(error: error)
+        let resolvedError = errorHandler.handle(error: error)
         return resolvedError is NetworkError ? .networkFailure(error) : .resolvedNetworkFailure(resolvedError)
     }
 }

--- a/B&W/Network/Endpoint.swift
+++ b/B&W/Network/Endpoint.swift
@@ -10,12 +10,6 @@ public protocol Requestable {
     func urlRequest() throws -> URLRequest
 }
 
-public protocol ResponseRequestable: Requestable {
-    associatedtype Response
-
-    var responseDecoder: ResponseDecoder { get }
-}
-
 public enum RequestError: Error {
     case componentsError
 }

--- a/B&W/Network/Endpoint.swift
+++ b/B&W/Network/Endpoint.swift
@@ -20,28 +20,25 @@ public enum RequestError: Error {
     case componentsError
 }
 
-public final class Endpoint<R>: ResponseRequestable {
-    public typealias Response = R
+// Endpoint should not hold the reference of ResponseDecoder and also define the Response generic type 
+// because Endpoint itself doesn't need them.
 
+// Endpoint is a tiny struct now.
+public struct Endpoint {
     private let config: RequestConfig
     private let path: String
     private let method: HTTPMethodType
-    public let responseDecoder: ResponseDecoder
 
-    public init(config: RequestConfig,
-                path: String,
-                method: HTTPMethodType,
-                responseDecoder: ResponseDecoder = JSONResponseDecoder()) {
+    public init(config: RequestConfig, path: String, method: HTTPMethodType) {
         self.config = config
         self.path = path
         self.method = method
-        self.responseDecoder = responseDecoder
     }
 }
 
 // Move config from method injection to constructor injection.
 // Config shouldn't change frequently, if config has to be changed, I would rather create a new one.
-extension Endpoint {
+extension Endpoint: Requestable {
     public func urlRequest() throws -> URLRequest {
         var urlRequest = URLRequest(url: try url())
         urlRequest.httpMethod = method.rawValue

--- a/B&WTests/Application/ProductsDependenciesContainerTests.swift
+++ b/B&WTests/Application/ProductsDependenciesContainerTests.swift
@@ -54,8 +54,9 @@ final class ProductsDependenciesContainerTests: XCTestCase {
             func cancel() {}
         }
         
-        func request<T: Decodable, E: ResponseRequestable>(with endpoint: E,
-                                                           completion: @escaping CompletionHandler<T>) -> NetworkCancellable? where E.Response == T {
+        func request<T: Decodable>(with endpoint: Requestable,
+                                   responseType: T.Type,
+                                   completion: @escaping CompletionHandler<T>) -> NetworkCancellable? {
             Cancellable()
         }
     }

--- a/B&WTests/Network/DefaultDataTransferServiceTests.swift
+++ b/B&WTests/Network/DefaultDataTransferServiceTests.swift
@@ -38,6 +38,28 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         wait(for: [exp], timeout: 1)
     }
     
+    func test_request_deliversParsingErrorOnDecodeError() {
+        let (sut, service) = makeSUT()
+        let endpoint = makeEndpoint()
+        
+        let exp = expectation(description: "Wait for completion")
+        _ = sut.request(with: endpoint) { result in
+            switch result {
+            case .success:
+                XCTFail("Should not be here")
+                
+            case let .failure(error):
+                guard case .parsing = error else {
+                    XCTFail("Should be a parsing error")
+                    return
+                }
+            }
+            exp.fulfill()
+        }
+        service.complete(with: Data("?".utf8))
+        wait(for: [exp], timeout: 1)
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #filePath,
@@ -49,8 +71,8 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         return (sut, service)
     }
     
-    private func makeEndpoint(baseURL: URL = anyURL()) -> Endpoint<String> {
+    private func makeEndpoint(baseURL: URL = anyURL()) -> Endpoint<Int> {
         let config = ApiRequestConfig(baseURL: anyURL())
-        return Endpoint<String>(config: config, path: "", method: .get)
+        return Endpoint<Int>(config: config, path: "", method: .get)
     }
 }

--- a/B&WTests/Network/DefaultDataTransferServiceTests.swift
+++ b/B&WTests/Network/DefaultDataTransferServiceTests.swift
@@ -44,6 +44,21 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         XCTFail("Should be a parsing error")
     }
     
+    func test_request_deliversNoResponseErrorWhenReceivedNoData() {
+        let (sut, service) = makeSUT()
+        let endpoint = makeEndpoint()
+        let noData: Data? = nil
+        
+        let receivedError = dataTransferError(on: sut, with: endpoint, when: {
+            service.complete(with: noData)
+        })
+        
+        if case .noResponse = receivedError {
+            return
+        }
+        XCTFail("Should be a noResponse error")
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #filePath,

--- a/B&WTests/Network/DefaultDataTransferServiceTests.swift
+++ b/B&WTests/Network/DefaultDataTransferServiceTests.swift
@@ -91,7 +91,7 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         let (sut, service) = makeSUT()
         let endpoint = makeEndpoint()
         
-        let task = sut.request(with: endpoint) { _ in }
+        let task = sut.request(with: endpoint, responseType: Int.self) { _ in }
         
         XCTAssertEqual(service.cancelCallCount, 0)
         
@@ -147,7 +147,7 @@ final class DefaultDataTransferServiceTests: XCTestCase {
                         line: UInt = #line) -> Result<Int, DataTransferError> {
         let exp = expectation(description: "Wait for completion")
         var receivedResult: Result<Int, DataTransferError>!
-        _ = sut.request(with: endpoint) { result in
+        _ = sut.request(with: endpoint, responseType: Int.self) { result in
             receivedResult = result
             exp.fulfill()
         }

--- a/B&WTests/Network/DefaultDataTransferServiceTests.swift
+++ b/B&WTests/Network/DefaultDataTransferServiceTests.swift
@@ -15,6 +15,30 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         XCTAssertEqual(service.requestCallCount, 0)
     }
     
+    func test_request_deliversNetworkErrorOnServiceError() {
+        let (sut, service) = makeSUT()
+        let config = ApiRequestConfig(baseURL: anyURL())
+        let endpoint = Endpoint<String>(config: config, path: "", method: .get)
+        let anyNetworkError = NetworkError.urlGeneration
+        
+        let exp = expectation(description: "Wait for completion")
+        _ = sut.request(with: endpoint) { result in
+            switch result {
+            case .success:
+                XCTFail("Should not be here")
+                
+            case let .failure(error):
+                guard case .networkFailure = error else {
+                    XCTFail("Should be a network error")
+                    return
+                }
+            }
+            exp.fulfill()
+        }
+        service.complete(with: anyNetworkError)
+        wait(for: [exp], timeout: 1)
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #filePath,

--- a/B&WTests/Network/DefaultDataTransferServiceTests.swift
+++ b/B&WTests/Network/DefaultDataTransferServiceTests.swift
@@ -87,6 +87,19 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         XCTAssertEqual(decodedValue, expectedValue)
     }
     
+    func test_cancelTask_cancelsANetworkTaskProperly() {
+        let (sut, service) = makeSUT()
+        let endpoint = makeEndpoint()
+        
+        let task = sut.request(with: endpoint) { _ in }
+        
+        XCTAssertEqual(service.cancelCallCount, 0)
+        
+        task?.cancel()
+        
+        XCTAssertEqual(service.cancelCallCount, 1)
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(errorHandler: DataTransferErrorHandler = DefaultDataTransferErrorHandler(),
@@ -107,7 +120,7 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         switch result(on: sut, with: endpoint, when: action, file: file, line: line) {
         case let .success(value):
             return value
-        case let .failure(error):
+        case .failure:
             XCTFail("Should not fail", file: file, line: line)
             return nil
         }

--- a/B&WTests/Network/DefaultDataTransferServiceTests.swift
+++ b/B&WTests/Network/DefaultDataTransferServiceTests.swift
@@ -17,8 +17,7 @@ final class DefaultDataTransferServiceTests: XCTestCase {
     
     func test_request_deliversNetworkErrorOnServiceError() {
         let (sut, service) = makeSUT()
-        let config = ApiRequestConfig(baseURL: anyURL())
-        let endpoint = Endpoint<String>(config: config, path: "", method: .get)
+        let endpoint = makeEndpoint()
         let anyNetworkError = NetworkError.urlGeneration
         
         let exp = expectation(description: "Wait for completion")
@@ -48,5 +47,10 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         trackForMemoryLeaks(service, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, service)
+    }
+    
+    private func makeEndpoint(baseURL: URL = anyURL()) -> Endpoint<String> {
+        let config = ApiRequestConfig(baseURL: anyURL())
+        return Endpoint<String>(config: config, path: "", method: .get)
     }
 }

--- a/B&WTests/Network/DefaultDataTransferServiceTests.swift
+++ b/B&WTests/Network/DefaultDataTransferServiceTests.swift
@@ -1,0 +1,28 @@
+//
+//  DefaultDataTransferServiceTests.swift
+//  B&WTests
+//
+//  Created by Tsz-Lung on 06/04/2024.
+//
+
+import XCTest
+import B_W
+
+final class DefaultDataTransferServiceTests: XCTestCase {
+    func test_init_doesNotNotifyService() {
+        let (_, service) = makeSUT()
+        
+        XCTAssertEqual(service.requestCallCount, 0)
+    }
+    
+    // MARK: - Helpers
+    
+    private func makeSUT(file: StaticString = #filePath,
+                         line: UInt = #line) -> (sut: DefaultDataTransferService, service: NetworkServiceSpy) {
+        let service = NetworkServiceSpy()
+        let sut = DefaultDataTransferService(with: service)
+        trackForMemoryLeaks(service, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, service)
+    }
+}

--- a/B&WTests/Network/DefaultDataTransferServiceTests.swift
+++ b/B&WTests/Network/DefaultDataTransferServiceTests.swift
@@ -113,7 +113,7 @@ final class DefaultDataTransferServiceTests: XCTestCase {
     }
     
     private func decodedValue(on sut: DefaultDataTransferService,
-                              with endpoint: Endpoint<Int>,
+                              with endpoint: Endpoint,
                               when action: () -> Void,
                               file: StaticString = #filePath,
                               line: UInt = #line) -> Int? {
@@ -127,7 +127,7 @@ final class DefaultDataTransferServiceTests: XCTestCase {
     }
     
     private func dataTransferError(on sut: DefaultDataTransferService,
-                                   with endpoint: Endpoint<Int>,
+                                   with endpoint: Endpoint,
                                    when action: () -> Void,
                                    file: StaticString = #filePath,
                                    line: UInt = #line) -> DataTransferError? {
@@ -141,7 +141,7 @@ final class DefaultDataTransferServiceTests: XCTestCase {
     }
     
     private func result(on sut: DefaultDataTransferService,
-                        with endpoint: Endpoint<Int>,
+                        with endpoint: Endpoint,
                         when action: () -> Void,
                         file: StaticString = #filePath,
                         line: UInt = #line) -> Result<Int, DataTransferError> {
@@ -157,9 +157,9 @@ final class DefaultDataTransferServiceTests: XCTestCase {
         return receivedResult
     }
     
-    private func makeEndpoint(baseURL: URL = anyURL()) -> Endpoint<Int> {
+    private func makeEndpoint(baseURL: URL = anyURL()) -> Endpoint {
         let config = ApiRequestConfig(baseURL: anyURL())
-        return Endpoint<Int>(config: config, path: "", method: .get)
+        return Endpoint(config: config, path: "", method: .get)
     }
     
     private final class AlwaysReturnNSErrorHandler: DataTransferErrorHandler {

--- a/B&WTests/Network/EndpointTests.swift
+++ b/B&WTests/Network/EndpointTests.swift
@@ -50,7 +50,7 @@ final class EndpointTests: XCTestCase {
     private func makeSUT(baseURL: URL = URL(string: "https://any-url.com/")!,
                          path: String,
                          isFullPath: Bool = false,
-                         method: HTTPMethodType = .get) -> Endpoint<Any> {
+                         method: HTTPMethodType = .get) -> Endpoint {
         let config = ConfigStub(baseURL: baseURL)
         return Endpoint(config: config, path: path, method: method)
     }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Thank you for your time to go through my code. If you have any problems encounte
 I would like to write down some of my reflections after this technical test.
 
 ### About the generic Response type and ResponseDecoder in Endpoint
-I think `Endpoint` should not hold the reference of `ResponseDecoder` and also decide the `Response` generic type. It is because `Endpoint` doesn't need them. But if I want to move them away, I cannot find a good place. Putting them into `DataTransferService` is not quite right... Hoping to have a further discussion on this.
+~~I think `Endpoint` should not hold the reference of `ResponseDecoder` and also decide the `Response` generic type. It is because `Endpoint` doesn't need them. But if I want to move them away, I cannot find a good place. Putting them into `DataTransferService` is not quite right... Hoping to have a further discussion on this.~~
+
+Updated on 06/04/2024:
+`ResponseDecoder` and the `Response` generic type is removed from `Endpoint`. Now `DataTransferService.request` requires a `responseType` parameter, and `ResponseDecoder` is referenced in `DataTransferService`.
 
 ### About image caching
 If the images received from API is static, I would like to do caching, for improving the performance. It is rather easy to implement under clean architecture. Utilise the `decorator pattern`, wrapping my `DefaultLoadImageDataUseCase` class, conform to the same protocol. Then, I can intercept the message before and after the network API call. Check any cache before making an API call, and cache after image data response. The cache itself can be an in-memory one, starting from simple.


### PR DESCRIPTION
Now DataTransferService.request requires a responseType param and DataTransferService holds reference of ResponseDecoder.