### PR TITLE
Decouple ProductListItemCell from ProductsListViewController.

### DIFF
--- a/B&W/Application/ProductsDependenciesContainer.swift
+++ b/B&W/Application/ProductsDependenciesContainer.swift
@@ -29,10 +29,11 @@ final class ProductsDependenciesContainer {
     // MARK: - View Models
 
     private func makeProductsListViewModel(actions: ProductsListViewModelActions) -> ProductsListViewModel {
-        return DefaultProductsListViewModel(
-            useCase: makeGetProductsUseCase(),
-            actions: actions
-        )
+        return DefaultProductsListViewModel(useCase: makeGetProductsUseCase(), actions: actions)
+    }
+    
+    private func makeProductsListItemViewModel(product: Product) -> ProductsListItemViewModel {
+        return ProductsListItemViewModel(product: product, loadImageDataUseCase: loadImageDataUseCase)
     }
 
     private func makeProductDetailsViewModel(product: Product) -> ProductDetailsViewModel {
@@ -69,30 +70,10 @@ extension ProductsDependenciesContainer: GetProductsFlowCoordinatorDependencies 
             
             let cell = tableView.dequeueReusableCell(withIdentifier: ProductListItemCell.reuseIdentifier) as? ProductListItemCell
             cell?.fill(with: makeProductsListItemViewModel(product: product))
-            
             return cell
         }
         
         return listVC
-    }
-    
-    private func makeProductsListItemViewModel(product: Product) -> ProductsListItemViewModel {
-        return ProductsListItemViewModel(
-            product: product,
-            loadImageData: { [weak self] loadImageData in
-                guard let imagePath = product.imagePath else { return }
-                
-                // The actual image data loading logic encapsulated in ProductsListItemViewModel.loadImageData.
-                _ = self?.loadImageDataUseCase.load(for: imagePath) { result in
-                    switch result {
-                    case let .success(data):
-                        loadImageData(data)
-                    case .failure:
-                        break
-                    }
-                }
-            }
-        )
     }
 
     func makeProductDetailsViewController(product: Product) -> ProductDetailsViewController {

--- a/B&W/Presentation/ProductsList/View/ProductsListViewController.swift
+++ b/B&W/Presentation/ProductsList/View/ProductsListViewController.swift
@@ -1,8 +1,8 @@
 import UIKit
 
 final class ProductsListViewController: UITableViewController, StoryboardInstantiable {
-
     var viewModel: ProductsListViewModel!
+    var didCellForRow: ((UITableView, Product) -> UITableViewCell?)?
 
     // MARK: - Lifecycle
 
@@ -13,7 +13,7 @@ final class ProductsListViewController: UITableViewController, StoryboardInstant
     }
 
     private func bind(to viewModel: ProductsListViewModel) {
-        viewModel.items.observe(on: self) { [weak self] _ in self?.tableView.reloadData() }
+        viewModel.products.observe(on: self) { [weak self] _ in self?.tableView.reloadData() }
         viewModel.error.observe(on: self) { [weak self] in self?.showError($0) }
     }
 
@@ -30,25 +30,21 @@ final class ProductsListViewController: UITableViewController, StoryboardInstant
         view.viewModel = viewModel
         return view
     }
-
 }
 
 // MARK: - UITableViewDataSource, UITableViewDelegate
 
 extension ProductsListViewController {
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.items.value.count
+        return viewModel.products.value.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductListItemCell.reuseIdentifier,
-                                                       for: indexPath) as? ProductListItemCell else {
+        let product = viewModel.products.value[indexPath.row]
+        guard let cell = didCellForRow?(tableView, product) else {
             assertionFailure("Cannot dequeue reusable cell \(ProductListItemCell.self) with reuseIdentifier: \(ProductListItemCell.reuseIdentifier)")
             return UITableViewCell()
         }
-
-        cell.fill(with: viewModel.items.value[indexPath.row])
 
         return cell
     }

--- a/B&W/Presentation/ProductsList/ViewModel/ProductsListItemViewModel.swift
+++ b/B&W/Presentation/ProductsList/ViewModel/ProductsListItemViewModel.swift
@@ -1,38 +1,38 @@
 import Foundation
 
-struct ProductsListItemViewModel {
-    typealias LoadImageData = (@escaping (Data) -> Void) -> Void
-    
+final class ProductsListItemViewModel {
     let image: Observable<Data?>
     
     let name: String
     let price: String
     let description: String
-    
-    // Holding a image Data callback closure injected from DefaultProductsListViewModel.
-    private let loadImageData: LoadImageData
+    private let imagePath: URL?
+    private let loadImageDataUseCase: LoadImageDataUseCase
     
     init(product: Product,
-         loadImageData: @escaping LoadImageData,
+         loadImageDataUseCase: LoadImageDataUseCase,
          performOnMainQueue: @escaping PerformOnMainQueue = DispatchQueue.performOnMainQueue()) {
         self.name = product.name ?? ""
         self.price = product.price ?? ""
         self.description = product.description ?? ""
-        self.loadImageData = loadImageData
+        self.imagePath = product.imagePath
+        self.loadImageDataUseCase = loadImageDataUseCase
         self.image = Observable(nil, performOnMainQueue: performOnMainQueue)
-    }
-}
-
-extension ProductsListItemViewModel: Equatable {
-    static func == (lhs: ProductsListItemViewModel, rhs: ProductsListItemViewModel) -> Bool {
-        lhs.name == rhs.name && lhs.description == rhs.description && lhs.price == rhs.price && lhs.image === rhs.image
     }
 }
 
 extension ProductsListItemViewModel {
     func loadImage() {
-        loadImageData { data in
-            image.value = data
+        guard let imagePath else { return }
+        
+        // The actual image data loading logic encapsulated in ProductsListItemViewModel.loadImageData.
+        _ = loadImageDataUseCase.load(for: imagePath) { [weak self] result in
+            switch result {
+            case let .success(data):
+                self?.image.value = data
+            case .failure:
+                break
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ Updated on 06/04/2024:
 If the images received from API is static, I would like to do caching, for improving the performance. It is rather easy to implement under clean architecture. Utilise the `decorator pattern`, wrapping my `DefaultLoadImageDataUseCase` class, conform to the same protocol. Then, I can intercept the message before and after the network API call. Check any cache before making an API call, and cache after image data response. The cache itself can be an in-memory one, starting from simple.
 
 ### About the ProductsListItemViewModel and ProductListItemCell
-Now the `ProductsListItemViewModel` is created by `DefaultProductsListViewModel`. And because of that, `DefaultProductsListViewModel` has to carry the dependency which `ProductsListItemViewModel` needs only. Ideally, the component should only hold dependencies it needs. The root cause is that `ProductListItemCell` is created by `ProductsListViewController`, leading to their view models also being coupled. I've thought of decoupling them, however, due to the time limit, I can't do it at the moment.
+~~Now the `ProductsListItemViewModel` is created by `DefaultProductsListViewModel`. And because of that, `DefaultProductsListViewModel` has to carry the dependency which `ProductsListItemViewModel` needs only. Ideally, the component should only hold dependencies it needs. The root cause is that `ProductListItemCell` is created by `ProductsListViewController`, leading to their view models also being coupled. I've thought of decoupling them, however, due to the time limit, I can't do it at the moment.~~
+
+Updated on 06/04/2024:
+Now `ProductListItemCell` is created outside `ProductsListViewController`, unlocked the possibility of injecting a `ProductsListItemViewModel` into it.
+And also `ProductsListItemViewModel` is created outside `DefaultProductsListViewModel`, `DefaultProductsListViewModel` needn't to carry the dependency for `ProductsListItemViewModel` any more.
 
 ### About unit tests
 If I have time, I would write unit tests for ALL components (except SwiftUI view, no good ways to do unit test for SwiftUI). I am very satisfied to see more and more lines of code being covered, as an advocate of automated tests.:)


### PR DESCRIPTION
Unlocked the possibility of creating a ProductsListItemViewModel outside the DefaultProductsListViewModel, DefaultProductsListViewModel no longer has to carry the dependency for ProductsListItemViewModel.